### PR TITLE
Add serde support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,8 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo build --all-features --verbose
+  - cargo test --all-features --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ travis-ci = { repository = "dathinab/maybe-owned", branch = "master" }
 
 [dependencies]
 serde = { version = "1", optional = true }
+
+[dev-dependencies]
+serde_json = "1"
+serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ keywords = [
 
 [badges]
 travis-ci = { repository = "dathinab/maybe-owned", branch = "master" }
+
+[dependencies]
+serde = { version = "1", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,12 @@
 //! Take a look at it's documentation for more information.
 //!
 #![warn(missing_docs)]
+#[cfg(feature = "serde")]
+extern crate serde;
+
+#[cfg(feature = "serde")]
+mod serde_impls;
+
 use std::ops::Deref;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,34 @@ use self::MaybeOwned::*;
 /// // ok, MaybeOwned can do this (but can't do &str<->String as tread of)
 /// let _ = MaybeOwned::Owned(OpaqueFFI { ref1: 0 as *const u8 });
 /// ```
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// # extern crate serde_json;
+/// # extern crate maybe_owned;
+/// # #[cfg(feature = "serde")]
+/// # fn main() {
+/// # use maybe_owned::MaybeOwned;
+/// use std::collections::HashMap;
+///
+/// #[derive(Serialize, Deserialize)]
+/// struct SerializedData<'a> {
+///     data: MaybeOwned<'a, HashMap<String, i32>>,
+/// }
+///
+/// let mut map = HashMap::new();
+/// map.insert("answer".to_owned(), 42);
+///
+/// // serializing can use borrowed data to avoid unnecessary copying
+/// let bytes = serde_json::to_vec(&SerializedData { data: (&map).into() }).unwrap();
+///
+/// // deserializing creates owned data
+/// let deserialized: SerializedData = serde_json::from_slice(&bytes).unwrap();
+/// assert_eq!(deserialized.data["answer"], 42);
+/// # }
+/// # #[cfg(not(feature = "serde"))] fn main() {}
+/// ```
 #[derive(Debug)]
 pub enum MaybeOwned<'a, T: 'a> {
     /// owns T

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,0 +1,32 @@
+//! Serde `Serialize` and `Deserialize` implementations for `MaybeOwned`.
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use MaybeOwned;
+use MaybeOwned::*;
+
+impl<'a, T> Serialize for MaybeOwned<'a, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match *self {
+            Owned(ref v) => v.serialize(serializer),
+            Borrowed(v) => v.serialize(serializer),
+        }
+    }
+}
+
+impl<'a, 'de, T> Deserialize<'de> for MaybeOwned<'a, T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(Owned)
+    }
+}


### PR DESCRIPTION
This adds support for `serde::Serialize` and `serde::Deserialize` when the `"serde"` feature is enabled.

I included an example which matches what I plan to use this for, and added `serde_json` and `serde_derive` as dev-dependencies for it.

Closes #5.