### PR TITLE
Update github repository links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "provides a `MaybeOwned<'a,T>` type different to std's `Cow` it implements `From<T>` and `From<&'a T>` and does not require `ToOwned`"
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/dathinab/maybe-owned"
+repository = "https://github.com/rustonaut/maybe-owned"
 readme = "./README.md"
 categories = []
 keywords = [
@@ -16,7 +16,7 @@ keywords = [
 
 
 [badges]
-travis-ci = { repository = "dathinab/maybe-owned", branch = "master" }
+travis-ci = { repository = "rustonaut/maybe-owned", branch = "master" }
 
 [dependencies]
 serde = { version = "1", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# maybe-owned &emsp; [![Build Status](https://travis-ci.org/dathinab/maybe-owned.svg?branch=master)](https://travis-ci.org/dathinab/maybe-owned)
+# maybe-owned &emsp; [![Build Status](https://travis-ci.org/rustonaut/maybe-owned.svg?branch=master)](https://travis-ci.org/rustonaut/maybe-owned)
 
 **provides a `MaybeOwned<'a,T>` type different to std's `Cow` it implements `From<T>` and `From<&'a T>` and does not require `ToOwned`**
 


### PR DESCRIPTION
This updates the travis build status and github repositories to mention rustonaut rather than dathinab now that the latter redirects to the former.

Hope this is alright! I was just checking the travis-ci status after the last PR was merged, and noticed that the it was a dead link, and that the repository `https://github.com/dathinab/maybe-owned` redirects here.