### PR TITLE
Added MaybeOwnedMut and cleaned up along the way

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "maybe-owned"
-version = "0.3.2"
+version = "0.4.0"
 authors = [
 	"Philipp korber <philippkorber@gmail.com>",
 	"darkstalker <slayerbeast@gmail.com>",
-    "daboross <daboross@daboross.net>"
+    "daboross <daboross@daboross.net>",
+    "Zac Burns (That3Percent) <that3percent@gmail.com>"
 ]
 description = "provides a `MaybeOwned<'a,T>` type different to std's `Cow` it implements `From<T>` and `From<&'a T>` and does not require `ToOwned`"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maybe-owned"
-version = "0.4.0"
+version = "0.3.3"
 authors = [
 	"Philipp korber <philippkorber@gmail.com>",
 	"darkstalker <slayerbeast@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! This crate only provides the `MaybeOwned` enum
+//! This crate only provides the `MaybeOwned` and `MaybeOwnedMut` enums
 //!
-//! Take a look at it's documentation for more information.
+//! Take a look at their documentation for more information.
 //!
 #![warn(missing_docs)]
 #[cfg(feature = "serde")]
@@ -11,15 +11,12 @@ mod serde_impls;
 
 mod transitive_impl;
 
-use std::ops::Deref;
+use std::borrow::{Borrow, Cow};
 use std::cmp::Ordering;
-use std::hash::{Hash, Hasher};
 use std::fmt;
-use std::borrow::{Cow, Borrow};
+use std::hash::{Hash, Hasher};
+use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-
-
-use self::MaybeOwned::*;
 
 /// This type provides a way to store data to which you either have a
 /// reference to or which you do own.
@@ -36,7 +33,7 @@ use self::MaybeOwned::*;
 /// Another benefit lies in the ability to write API functions which accept
 /// a generic parameter `E: Into<MaybeOwned<'a, T>>` as the API consumer can
 /// pass `T`, `&'a T` and `MaybeOwned<'a, T>` as argument, without requiring
-/// a explicit `Cow::Onwed` or a split into two functions one accepting
+/// a explicit `Cow::Owned` or a split into two functions one accepting
 /// owed and the other borrowed values.
 ///
 /// # Alternatives
@@ -148,59 +145,144 @@ pub enum MaybeOwned<'a, T: 'a> {
     /// owns T
     Owned(T),
     /// has a reference to T
-    Borrowed(&'a T)
+    Borrowed(&'a T),
 }
 
-impl<'a, T> MaybeOwned<'a, T> {
+/// This type is basically the same as `MaybeOwned`,
+/// but works with mutable references.
+#[derive(Debug)]
+pub enum MaybeOwnedMut<'a, T: 'a> {
+    /// owns T
+    Owned(T),
+    /// has a reference to T
+    Borrowed(&'a mut T),
+}
 
-    /// returns true if the data is owned else false
-    pub fn is_owned(&self) -> bool {
-        match *self {
-            Owned(_) => true,
-            Borrowed(_) => false
+macro_rules! common_impls {
+    ($Name:ident) => {
+        impl<T> $Name<'_, T> {
+            /// returns true if the data is owned else false
+            pub fn is_owned(&self) -> bool {
+                match self {
+                    Self::Owned(_) => true,
+                    Self::Borrowed(_) => false,
+                }
+            }
         }
-    }
-}
 
-impl<'a, T> Deref for MaybeOwned<'a, T> {
-    type Target = T;
+        impl<T> Deref for $Name<'_, T> {
+            type Target = T;
 
-    fn deref(&self) -> &T {
-        match *self {
-            Owned(ref v) => v,
-            Borrowed(v) => v
+            fn deref(&self) -> &T {
+                match self {
+                    Self::Owned(v) => v,
+                    Self::Borrowed(v) => v,
+                }
+            }
         }
-    }
+
+        impl<T> AsRef<T> for $Name<'_, T> {
+            fn as_ref(&self) -> &T {
+                self
+            }
+        }
+
+        impl<T> From<T> for $Name<'_, T> {
+            fn from(v: T) -> Self {
+                Self::Owned(v)
+            }
+        }
+
+        impl<T> Borrow<T> for $Name<'_, T> {
+            fn borrow(&self) -> &T {
+                self
+            }
+        }
+
+        impl<T: Default> Default for $Name<'_, T> {
+            fn default() -> Self {
+                Self::Owned(T::default())
+            }
+        }
+
+        impl<'b, A: PartialEq<B>, B> PartialEq<$Name<'b, B>> for $Name<'_, A> {
+            #[inline]
+            fn eq(&self, other: &$Name<'b, B>) -> bool {
+                PartialEq::eq(self.deref(), other.deref())
+            }
+        }
+
+        impl<'a, T: Eq> Eq for $Name<'a, T> {}
+
+        impl<T: FromStr> FromStr for $Name<'_, T> {
+            type Err = T::Err;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok(Self::Owned(T::from_str(s)?))
+            }
+        }
+
+        // TODO: Specify RHS
+        impl<T: PartialOrd> PartialOrd for $Name<'_, T> {
+            #[inline]
+            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+                PartialOrd::partial_cmp(self.deref(), other.deref())
+            }
+        }
+
+        impl<T: Ord> Ord for $Name<'_, T> {
+            #[inline]
+            fn cmp(&self, other: &Self) -> Ordering {
+                Ord::cmp(self.deref(), other.deref())
+            }
+        }
+
+        impl<T: Hash> Hash for $Name<'_, T> {
+            #[inline]
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                Hash::hash(self.deref(), state)
+            }
+        }
+
+        impl<'a, T: fmt::Display> fmt::Display for $Name<'a, T> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self {
+                    Self::Owned(o) => fmt::Display::fmt(o, f),
+                    Self::Borrowed(b) => fmt::Display::fmt(b, f),
+                }
+            }
+        }
+
+        impl<T: Clone> $Name<'_, T> {
+            /// Extracts the owned data.
+            ///
+            /// If the data is borrowed it is cloned before being extracted.
+            pub fn into_owned(self) -> T {
+                match self {
+                    Self::Owned(v) => v,
+                    Self::Borrowed(v) => v.clone(),
+                }
+            }
+        }
+    };
 }
 
-impl<'a, T> AsRef<T> for MaybeOwned<'a, T> {
-    fn as_ref(&self) -> &T {
-        self
-    }
-}
-
-impl<'a, T> Borrow<T> for MaybeOwned<'a, T> {
-    fn borrow(&self) -> &T {
-        self
-    }
-}
+common_impls!(MaybeOwned);
+common_impls!(MaybeOwnedMut);
 
 impl<'a, T> From<&'a T> for MaybeOwned<'a, T> {
-    fn from(v: &'a T) -> MaybeOwned<'a, T> {
-        Borrowed(v)
+    fn from(v: &'a T) -> Self {
+        Self::Borrowed(v)
     }
 }
 
-
-impl<'a, T> From<T> for MaybeOwned<'a, T> {
-    fn from(v: T) -> MaybeOwned<'a, T> {
-        Owned(v)
+impl<'a, T> From<&'a mut T> for MaybeOwnedMut<'a, T> {
+    fn from(v: &'a mut T) -> Self {
+        Self::Borrowed(v)
     }
 }
 
-impl<'a, T> From<Cow<'a, T>> for MaybeOwned<'a, T>
-    where T: ToOwned<Owned=T>,
-{
+impl<'a, T: ToOwned<Owned = T>> From<Cow<'a, T>> for MaybeOwned<'a, T> {
     fn from(cow: Cow<'a, T>) -> MaybeOwned<'a, T> {
         match cow {
             Cow::Owned(v) => MaybeOwned::Owned(v),
@@ -209,9 +291,7 @@ impl<'a, T> From<Cow<'a, T>> for MaybeOwned<'a, T>
     }
 }
 
-impl<'a, T> Into<Cow<'a, T>> for MaybeOwned<'a, T>
-    where T: ToOwned<Owned=T>,
-{
+impl<'a, T: ToOwned<Owned = T>> Into<Cow<'a, T>> for MaybeOwned<'a, T> {
     fn into(self) -> Cow<'a, T> {
         match self {
             MaybeOwned::Owned(v) => Cow::Owned(v),
@@ -220,84 +300,17 @@ impl<'a, T> Into<Cow<'a, T>> for MaybeOwned<'a, T>
     }
 }
 
-impl<'a, T> Default for MaybeOwned<'a, T> where T: Default {
-    fn default() -> Self {
-        Owned(T::default())
-    }
-}
-
-
-impl<'a, T> Clone for MaybeOwned<'a, T> where T: Clone {
-    fn clone(&self) -> MaybeOwned<'a, T> {
-        match *self {
-            Owned(ref v) => Owned(v.clone()),
-            Borrowed(v) => Borrowed(v)
+impl<T: Clone> Clone for MaybeOwned<'_, T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Owned(v) => Self::Owned(v.clone()),
+            Self::Borrowed(v) => Self::Borrowed(v),
         }
     }
 }
 
-impl<'a, 'b, A, B> PartialEq<MaybeOwned<'b, B>> for MaybeOwned<'a, A>
-    where A: PartialEq<B>
-{
-    #[inline]
-    fn eq(&self, other: &MaybeOwned<'b, B>) -> bool {
-        PartialEq::eq(self.deref(), other.deref())
-    }
-}
-
-impl<'a, T> Eq for MaybeOwned<'a, T> where T: Eq {}
-
-impl<'a, T> PartialOrd for MaybeOwned<'a, T>
-    where T: PartialOrd
-{
-    #[inline]
-    fn partial_cmp(&self, other: &MaybeOwned<'a, T>) -> Option<Ordering> {
-        PartialOrd::partial_cmp(self.deref(), other.deref())
-    }
-}
-
-impl<'a, T> Ord for MaybeOwned<'a, T>
-    where T: Ord
-{
-    #[inline]
-    fn cmp(&self, other: &MaybeOwned<'a, T>) -> Ordering {
-        Ord::cmp(self.deref(), other.deref())
-    }
-}
-
-impl<'a, T> Hash for MaybeOwned<'a, T>
-    where T: Hash
-{
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        Hash::hash(self.deref(), state)
-    }
-}
-
-impl<'a, T> fmt::Display for MaybeOwned<'a, T>
-    where T: fmt::Display
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Owned(ref o) => fmt::Display::fmt(o, f),
-            Borrowed(b) => fmt::Display::fmt(b, f),
-        }
-    }
-}
-
-impl<'a, T> FromStr for MaybeOwned<'a, T>
-    where T: FromStr
-{
-    type Err = T::Err;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(MaybeOwned::Owned(T::from_str(s)?))
-    }
-}
-
-impl<'a, T> MaybeOwned<'a, T> where T: Clone {
-
-    /// Aquires a mutable reference to owned data.
+impl<T: Clone> MaybeOwned<'_, T> {
+    /// Acquires a mutable reference to owned data.
     ///
     /// Clones data if it is not already owned.
     ///
@@ -323,33 +336,30 @@ impl<'a, T> MaybeOwned<'a, T> where T: Clone {
     ///
     pub fn to_mut(&mut self) -> &mut T {
         match *self {
-            Owned(ref mut v) => v,
-            Borrowed(v) => {
-                *self = Owned(v.clone());
+            Self::Owned(ref mut v) => v,
+            Self::Borrowed(v) => {
+                *self = Self::Owned(v.clone());
                 match *self {
-                    Owned(ref mut v) => v,
-                    Borrowed(..) => unreachable!()
+                    Self::Owned(ref mut v) => v,
+                    Self::Borrowed(..) => unreachable!(),
                 }
             }
-
-        }
-    }
-
-    /// Extracts the owned data.
-    ///
-    /// If the data is borrowed it is cloned before being extracted.
-    pub fn into_owned(self) -> T {
-        match self {
-            Owned(v) => v,
-            Borrowed(v) => v.clone()
         }
     }
 }
 
+impl<T> DerefMut for MaybeOwnedMut<'_, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        match self {
+            Self::Owned(v) => v,
+            Self::Borrowed(v) => v,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use super::MaybeOwned;
+    use super::*;
 
     type TestType = Vec<()>;
 
@@ -368,7 +378,6 @@ mod tests {
         //ty check if it accepts references
         let data = TestType::default();
         assert!(with_into(data).is_owned())
-
     }
     #[test]
     fn into_with_borrow() {
@@ -403,11 +412,10 @@ mod tests {
 
     #[test]
     fn into_inner() {
-        let data = vec![1u32,2];
+        let data = vec![1u32, 2];
         let maybe: MaybeOwned<Vec<u32>> = (&data).into();
         assert_eq!(data, maybe.into_owned());
     }
-
 
     #[test]
     fn has_default() {
@@ -420,7 +428,7 @@ mod tests {
     fn has_clone() {
         #[derive(Clone)]
         struct TestType(u8);
-        let _x  = TestType(12).clone();
+        let _x = TestType(12).clone();
     }
 
     #[test]
@@ -508,7 +516,9 @@ mod tests {
     fn from_cow() {
         use std::borrow::Cow;
 
-        fn test<'a, V: Into<MaybeOwned<'a, i32>>>(v: V, n: i32) { assert_eq!(*v.into(), n) }
+        fn test<'a, V: Into<MaybeOwned<'a, i32>>>(v: V, n: i32) {
+            assert_eq!(*v.into(), n)
+        }
 
         let n = 33;
         test(Cow::Owned(42), 42);
@@ -519,7 +529,9 @@ mod tests {
     fn into_cow() {
         use std::borrow::Cow;
 
-        fn test<'a, V: Into<Cow<'a, i32>>>(v: V, n: i32) { assert_eq!(*v.into(), n) }
+        fn test<'a, V: Into<Cow<'a, i32>>>(v: V, n: i32) {
+            assert_eq!(*v.into(), n)
+        }
 
         let n = 33;
         test(MaybeOwned::Owned(42), 42);
@@ -536,13 +548,10 @@ mod tests {
 
     #[test]
     fn as_ref() {
-        let data  = TestType::default();
+        let data = TestType::default();
         let maybe_owned = MaybeOwned::Borrowed(&data);
         let _ref: &TestType = maybe_owned.as_ref();
-        assert_eq!(
-            &data as *const _ as usize,
-            _ref as *const _ as usize
-        );
+        assert_eq!(&data as *const _ as usize, _ref as *const _ as usize);
     }
 
     #[test]
@@ -552,9 +561,15 @@ mod tests {
         let data = TestType::default();
         let maybe_owned = MaybeOwned::Borrowed(&data);
         let _ref: &TestType = maybe_owned.borrow();
-        assert_eq!(
-            &data as *const _ as usize,
-            _ref as *const _ as usize
-        );
+        assert_eq!(&data as *const _ as usize, _ref as *const _ as usize);
+    }
+
+    #[test]
+    fn reborrow_mut() {
+        let value = vec![0u32];
+        let mut value = MaybeOwnedMut::Owned(value);
+        let mut reborrow = MaybeOwnedMut::Borrowed(value.deref_mut());
+        reborrow.push(1);
+        assert_eq!(&[0, 1], &value[..]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,15 @@ impl<T> DerefMut for MaybeOwnedMut<'_, T> {
     }
 }
 
+impl<T> AsMut<T> for MaybeOwnedMut<'_, T> {
+    fn as_mut(&mut self) -> &mut T {
+        match self {
+            Self::Owned(v) => v,
+            Self::Borrowed(v) => v,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,32 +1,29 @@
 //! Serde `Serialize` and `Deserialize` implementations for `MaybeOwned`.
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use MaybeOwned;
-use MaybeOwned::*;
+use {MaybeOwned, MaybeOwnedMut};
 
-impl<'a, T> Serialize for MaybeOwned<'a, T>
-where
-    T: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match *self {
-            Owned(ref v) => v.serialize(serializer),
-            Borrowed(v) => v.serialize(serializer),
+macro_rules! serde_impls {
+    ($Name:ident) => {
+        impl<'a, T: Serialize> Serialize for $Name<'a, T> {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                match self {
+                    Self::Owned(v) => v.serialize(serializer),
+                    Self::Borrowed(v) => v.serialize(serializer),
+                }
+            }
         }
-    }
+
+        impl<'a, 'de, T: Deserialize<'de>> Deserialize<'de> for $Name<'a, T> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                T::deserialize(deserializer).map(Self::Owned)
+            }
+        }
+    };
 }
 
-impl<'a, 'de, T> Deserialize<'de> for MaybeOwned<'a, T>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        T::deserialize(deserializer).map(Owned)
-    }
-}
+serde_impls!(MaybeOwned);
+serde_impls!(MaybeOwnedMut);


### PR DESCRIPTION
This PR adds the `MaybeOwnedMut` type, which is very similar to the `MaybeOwned` type but provides mutable access.

To avoid duplication, many impls were moved into a macro.

Along the way, spelling errors were fixed (eg: "Onwed" -> "Owned"), and syntax was modernized: Eg:
```
impl<‘a, T> FromStr for MaybeOwned<‘a, T>  
   where
       T : FromStr {
```
becomes…
```
impl<T: FromStr> FromStr for MaybeOwned<‘_, T> {
```