### PR TITLE
Add clone_ref and clone_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ macro_rules! common_impls {
             }
 
             /// Returns a new `MaybeOwned::Borrowed` without cloning the data.
-            pub fn clone_ref<'a>(&'a self) -> MaybeOwned<'a, T> {
+            pub fn clone_ref(&self) -> MaybeOwned<'_, T> {
                 match self {
                     Self::Owned(v) => MaybeOwned::Borrowed(v),
                     Self::Borrowed(v) => MaybeOwned::Borrowed(v),
@@ -411,7 +411,7 @@ impl<T> BorrowMut<T> for MaybeOwnedMut<'_, T> {
 
 impl<T> MaybeOwnedMut<'_, T> {
     /// Returns a new `MaybeOwnedMut::Borrowed` without cloning the data.
-    pub fn clone_mut<'a>(&'a mut self) -> MaybeOwnedMut<'a, T> {
+    pub fn clone_mut(&mut self) -> MaybeOwnedMut<'_, T> {
         match self {
             Self::Owned(v) => MaybeOwnedMut::Borrowed(v),
             Self::Borrowed(v) => MaybeOwnedMut::Borrowed(v),


### PR DESCRIPTION
Related to #8 

These methods return a new `Borrowed(T)` without cloning the data. This is useful in particular cases.

### Example

```rust
struct Ctx<'a> {
    data: MaybeOwnedMut<'a, Data>,
    // TODO: more fields
}

impl Ctx<'_> {
    fn new(data: Data) -> Ctx<'_> {
        Ctx {
            data: data.into(),
            // TODO: more fields
        }
    }

    // A convenient function for struct update syntax like `Ctx { /* Something */, ..ctx.clone() }`
    fn clone(&mut self) -> Ctx<'_> {
        Ctx {
            data: self.data.clone_mut(),
            // TODO: more fields
        }
    }

    fn with_data(&mut self, data: Data) -> Ctx<'_> {
        Ctx {
            data: data.into(),
            ..self.clone()
        }
    }
}
```